### PR TITLE
Update ListCommand to display help

### DIFF
--- a/src/main/java/eatwhere/foodguide/logic/commands/ListCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/ListCommand.java
@@ -2,6 +2,8 @@ package eatwhere.foodguide.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
+
 import eatwhere.foodguide.model.Model;
 
 /**
@@ -13,10 +15,27 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Listed all eateries";
 
+    public static final String MESSAGE_HELP = "list - Lists all eateries.\n"
+            + "Usage: list [-h]";
+
+    /** Help message should be displayed in the response box. */
+    private final boolean DisplayHelp;
+
+    public ListCommand() {
+        this.DisplayHelp = false;
+    }
+    public ListCommand(boolean DisplayHelp) {
+        this.DisplayHelp = DisplayHelp;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+
+        if(DisplayHelp) {
+            return new CommandResult(MESSAGE_HELP);
+        }
+
         model.updateFilteredEateryList(Model.PREDICATE_SHOW_ALL_EATERIES);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/eatwhere/foodguide/logic/commands/ListCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/ListCommand.java
@@ -17,20 +17,20 @@ public class ListCommand extends Command {
             + "Usage: list [-h]";
 
     /** Help message should be displayed in the response box. */
-    private final boolean DisplayHelp;
+    private final boolean isDisplayHelp;
 
     public ListCommand() {
-        this.DisplayHelp = false;
+        this.isDisplayHelp = false;
     }
-    public ListCommand(boolean DisplayHelp) {
-        this.DisplayHelp = DisplayHelp;
+    public ListCommand(boolean isDisplayHelp) {
+        this.isDisplayHelp = isDisplayHelp;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
 
-        if(DisplayHelp) {
+        if (isDisplayHelp) {
             return new CommandResult(MESSAGE_HELP);
         }
 

--- a/src/main/java/eatwhere/foodguide/logic/commands/ListCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/ListCommand.java
@@ -2,8 +2,6 @@ package eatwhere.foodguide.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.List;
-
 import eatwhere.foodguide.model.Model;
 
 /**

--- a/src/main/java/eatwhere/foodguide/logic/parser/AddCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/AddCommandParser.java
@@ -8,7 +8,6 @@ import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_TAG;
 import static eatwhere.foodguide.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
 import eatwhere.foodguide.commons.core.Messages;
 import eatwhere.foodguide.logic.commands.AddCommand;

--- a/src/main/java/eatwhere/foodguide/logic/parser/AddCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/AddCommandParser.java
@@ -5,6 +5,7 @@ import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_NAME;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_PHONE;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_TAG;
+import static eatwhere.foodguide.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -47,14 +48,6 @@ public class AddCommandParser implements Parser<AddCommand> {
         Eatery eatery = new Eatery(name, phone, email, location, tagList);
 
         return new AddCommand(eatery);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/eatwhere/foodguide/logic/parser/CliSyntax.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/CliSyntax.java
@@ -6,10 +6,11 @@ package eatwhere.foodguide.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("n/");
-    public static final Prefix PREFIX_PHONE = new Prefix("p/");
-    public static final Prefix PREFIX_EMAIL = new Prefix("e/");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_NAME = new Prefix("-n");
+    public static final Prefix PREFIX_PHONE = new Prefix("-p");
+    public static final Prefix PREFIX_EMAIL = new Prefix("-e");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("-a");
+    public static final Prefix PREFIX_TAG = new Prefix("-t");
+    public static final Prefix PREFIX_HELP = new Prefix("-h");
 
 }

--- a/src/main/java/eatwhere/foodguide/logic/parser/FoodGuideParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/FoodGuideParser.java
@@ -58,7 +58,7 @@ public class FoodGuideParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/eatwhere/foodguide/logic/parser/ListCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/ListCommandParser.java
@@ -1,0 +1,26 @@
+package eatwhere.foodguide.logic.parser;
+
+import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_HELP;
+import static eatwhere.foodguide.logic.parser.ParserUtil.arePrefixesPresent;
+
+import eatwhere.foodguide.logic.commands.ListCommand;
+
+/**
+ * Parses input arguments and creates a new ListCommand object
+ */
+public class ListCommandParser implements Parser<ListCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     */
+    public ListCommand parse(String args) {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_HELP);
+
+        if (arePrefixesPresent(argMultimap, PREFIX_HELP)) {
+            return new ListCommand(true);
+        }
+        return new ListCommand();
+    }
+
+}

--- a/src/main/java/eatwhere/foodguide/logic/parser/ParserUtil.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/ParserUtil.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import eatwhere.foodguide.commons.core.index.Index;
 import eatwhere.foodguide.commons.util.StringUtil;
@@ -121,4 +122,13 @@ public class ParserUtil {
         }
         return tagSet;
     }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
 }


### PR DESCRIPTION
In order to improve the ease of use of the food guide, users should be able to easily get the usage syntax for any command without having to open up the help window or user guide.

A new prefix "-h" (for help) is added to facilitate this. Appending "-h" to any command should override existing behavior and instead display a description of the command as well as its usage.

Similar changes will be made to all other commands, with the exception of "help", for that is redundant.