### PR TITLE
Simple find by tags and location

### DIFF
--- a/src/main/java/eatwhere/foodguide/commons/core/Messages.java
+++ b/src/main/java/eatwhere/foodguide/commons/core/Messages.java
@@ -8,6 +8,6 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_EATERY_DISPLAYED_INDEX = "The eatery index provided is invalid";
-    public static final String MESSAGE_EATERIES_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_EATERIES_LISTED_OVERVIEW = "%1$d eateries listed!";
 
 }

--- a/src/main/java/eatwhere/foodguide/logic/commands/FindLocationCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/FindLocationCommand.java
@@ -1,10 +1,10 @@
 package eatwhere.foodguide.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
 import eatwhere.foodguide.commons.core.Messages;
 import eatwhere.foodguide.model.Model;
 import eatwhere.foodguide.model.eatery.LocationContainsKeywordsPredicate;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Finds and lists all eateries in food guide whose tags contains any of the argument keywords.

--- a/src/main/java/eatwhere/foodguide/logic/commands/FindLocationCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/FindLocationCommand.java
@@ -1,0 +1,42 @@
+package eatwhere.foodguide.logic.commands;
+
+import eatwhere.foodguide.commons.core.Messages;
+import eatwhere.foodguide.model.Model;
+import eatwhere.foodguide.model.eatery.LocationContainsKeywordsPredicate;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Finds and lists all eateries in food guide whose tags contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FindLocationCommand extends Command {
+
+    public static final String COMMAND_WORD = "findLocation";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all eateries whose location matches any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " mala";
+
+    private final LocationContainsKeywordsPredicate predicate;
+
+    public FindLocationCommand(LocationContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredEateryList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_EATERIES_LISTED_OVERVIEW, model.getFilteredEateryList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindLocationCommand // instanceof handles nulls
+                && predicate.equals(((FindLocationCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/eatwhere/foodguide/logic/commands/FindTagCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/FindTagCommand.java
@@ -1,0 +1,42 @@
+package eatwhere.foodguide.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import eatwhere.foodguide.commons.core.Messages;
+import eatwhere.foodguide.model.Model;
+import eatwhere.foodguide.model.eatery.TagsContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all eateries in food guide whose tags contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FindTagCommand extends Command {
+
+    public static final String COMMAND_WORD = "findTag";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all eateries whose list of tags matches any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " mala";
+
+    private final TagsContainsKeywordsPredicate predicate;
+
+    public FindTagCommand(TagsContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredEateryList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_EATERIES_LISTED_OVERVIEW, model.getFilteredEateryList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindTagCommand // instanceof handles nulls
+                && predicate.equals(((FindTagCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/eatwhere/foodguide/logic/parser/FindLocationCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/FindLocationCommandParser.java
@@ -1,0 +1,32 @@
+package eatwhere.foodguide.logic.parser;
+
+import eatwhere.foodguide.commons.core.Messages;
+import eatwhere.foodguide.logic.commands.FindLocationCommand;
+import eatwhere.foodguide.logic.parser.exceptions.ParseException;
+import eatwhere.foodguide.model.eatery.LocationContainsKeywordsPredicate;
+
+import java.util.Arrays;
+
+/**
+ * Parses input arguments and creates a new FindCommand object
+ */
+public class FindLocationCommandParser implements Parser<FindLocationCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindLocationCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, FindLocationCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindLocationCommand(new LocationContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/eatwhere/foodguide/logic/parser/FindLocationCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/FindLocationCommandParser.java
@@ -1,11 +1,11 @@
 package eatwhere.foodguide.logic.parser;
 
+import java.util.Arrays;
+
 import eatwhere.foodguide.commons.core.Messages;
 import eatwhere.foodguide.logic.commands.FindLocationCommand;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 import eatwhere.foodguide.model.eatery.LocationContainsKeywordsPredicate;
-
-import java.util.Arrays;
 
 /**
  * Parses input arguments and creates a new FindCommand object

--- a/src/main/java/eatwhere/foodguide/logic/parser/FindTagCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/FindTagCommandParser.java
@@ -1,0 +1,32 @@
+package eatwhere.foodguide.logic.parser;
+
+import java.util.Arrays;
+
+import eatwhere.foodguide.commons.core.Messages;
+import eatwhere.foodguide.logic.commands.FindTagCommand;
+import eatwhere.foodguide.logic.parser.exceptions.ParseException;
+import eatwhere.foodguide.model.eatery.TagsContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindCommand object
+ */
+public class FindTagCommandParser implements Parser<FindTagCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindTagCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, FindTagCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindTagCommand(new TagsContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/eatwhere/foodguide/logic/parser/FoodGuideParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/FoodGuideParser.java
@@ -11,6 +11,7 @@ import eatwhere.foodguide.logic.commands.DeleteCommand;
 import eatwhere.foodguide.logic.commands.EditCommand;
 import eatwhere.foodguide.logic.commands.ExitCommand;
 import eatwhere.foodguide.logic.commands.FindCommand;
+import eatwhere.foodguide.logic.commands.FindTagCommand;
 import eatwhere.foodguide.logic.commands.HelpCommand;
 import eatwhere.foodguide.logic.commands.ListCommand;
 import eatwhere.foodguide.logic.commands.TagCommand;
@@ -73,6 +74,9 @@ public class FoodGuideParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case FindTagCommand.COMMAND_WORD:
+            return new FindTagCommandParser().parse(arguments);
 
         default:
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/eatwhere/foodguide/logic/parser/FoodGuideParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/FoodGuideParser.java
@@ -11,6 +11,7 @@ import eatwhere.foodguide.logic.commands.DeleteCommand;
 import eatwhere.foodguide.logic.commands.EditCommand;
 import eatwhere.foodguide.logic.commands.ExitCommand;
 import eatwhere.foodguide.logic.commands.FindCommand;
+import eatwhere.foodguide.logic.commands.FindLocationCommand;
 import eatwhere.foodguide.logic.commands.FindTagCommand;
 import eatwhere.foodguide.logic.commands.HelpCommand;
 import eatwhere.foodguide.logic.commands.ListCommand;
@@ -77,6 +78,9 @@ public class FoodGuideParser {
 
         case FindTagCommand.COMMAND_WORD:
             return new FindTagCommandParser().parse(arguments);
+
+        case FindLocationCommand.COMMAND_WORD:
+            return new FindLocationCommandParser().parse(arguments);
 
         default:
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/eatwhere/foodguide/model/eatery/LocationContainsKeywordsPredicate.java
+++ b/src/main/java/eatwhere/foodguide/model/eatery/LocationContainsKeywordsPredicate.java
@@ -1,9 +1,9 @@
 package eatwhere.foodguide.model.eatery;
 
-import eatwhere.foodguide.commons.util.StringUtil;
-
 import java.util.List;
 import java.util.function.Predicate;
+
+import eatwhere.foodguide.commons.util.StringUtil;
 
 /**
  * Tests that a {@code Eatery}'s {@code Name} matches any of the keywords given.

--- a/src/main/java/eatwhere/foodguide/model/eatery/LocationContainsKeywordsPredicate.java
+++ b/src/main/java/eatwhere/foodguide/model/eatery/LocationContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package eatwhere.foodguide.model.eatery;
+
+import eatwhere.foodguide.commons.util.StringUtil;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Eatery}'s {@code Name} matches any of the keywords given.
+ */
+public class LocationContainsKeywordsPredicate implements Predicate<Eatery> {
+    private final List<String> keywords;
+
+    public LocationContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Eatery eatery) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(eatery.getLocation().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof LocationContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((LocationContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/eatwhere/foodguide/model/eatery/TagsContainsKeywordsPredicate.java
+++ b/src/main/java/eatwhere/foodguide/model/eatery/TagsContainsKeywordsPredicate.java
@@ -1,0 +1,37 @@
+package eatwhere.foodguide.model.eatery;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import eatwhere.foodguide.model.tag.Tag;
+import eatwhere.foodguide.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Eatery}'s {@code Name} matches any of the keywords given.
+ */
+public class TagsContainsKeywordsPredicate implements Predicate<Eatery> {
+    private final List<String> keywords;
+
+    public TagsContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Eatery eatery) {
+        StringBuilder builder = new StringBuilder();
+        for (Tag t: eatery.getTags()) {
+            builder.append(t.tagName).append(" ");
+        }
+
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(builder.toString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagsContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TagsContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/eatwhere/foodguide/model/eatery/TagsContainsKeywordsPredicate.java
+++ b/src/main/java/eatwhere/foodguide/model/eatery/TagsContainsKeywordsPredicate.java
@@ -3,8 +3,8 @@ package eatwhere.foodguide.model.eatery;
 import java.util.List;
 import java.util.function.Predicate;
 
-import eatwhere.foodguide.model.tag.Tag;
 import eatwhere.foodguide.commons.util.StringUtil;
+import eatwhere.foodguide.model.tag.Tag;
 
 /**
  * Tests that a {@code Eatery}'s {@code Name} matches any of the keywords given.


### PR DESCRIPTION
Currently, this works as 2 separate commands for now, `findTag` and `findLocation`. In this implementation, we can only search by one kind of parameter at a time.

Future work:
- Merging the various find commands to parse the various different tags
- Allowing cross-field searches (e.g. find by both location and price)
- Finding by other fields yet to be implemented (i.e. price)