### PR TITLE
Add help parameter to display command usage

### DIFF
--- a/src/main/java/eatwhere/foodguide/logic/Logic.java
+++ b/src/main/java/eatwhere/foodguide/logic/Logic.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import eatwhere.foodguide.commons.core.GuiSettings;
 import eatwhere.foodguide.logic.commands.CommandResult;
 import eatwhere.foodguide.logic.commands.exceptions.CommandException;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 import eatwhere.foodguide.model.Model;
 import eatwhere.foodguide.model.ReadOnlyFoodGuide;
@@ -22,7 +23,7 @@ public interface Logic {
      * @throws CommandException If an error occurs during command execution.
      * @throws ParseException If an error occurs during parsing.
      */
-    CommandResult execute(String commandText) throws CommandException, ParseException;
+    CommandResult execute(String commandText) throws CommandException, ParseException, DisplayCommandHelpException;
 
     /**
      * Returns the FoodGuide.

--- a/src/main/java/eatwhere/foodguide/logic/LogicManager.java
+++ b/src/main/java/eatwhere/foodguide/logic/LogicManager.java
@@ -10,6 +10,7 @@ import eatwhere.foodguide.logic.commands.Command;
 import eatwhere.foodguide.logic.commands.CommandResult;
 import eatwhere.foodguide.logic.commands.exceptions.CommandException;
 import eatwhere.foodguide.logic.parser.FoodGuideParser;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 import eatwhere.foodguide.model.Model;
 import eatwhere.foodguide.model.ReadOnlyFoodGuide;
@@ -38,7 +39,8 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public CommandResult execute(String commandText) throws CommandException, ParseException {
+    public CommandResult execute(String commandText) throws CommandException, ParseException,
+            DisplayCommandHelpException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;

--- a/src/main/java/eatwhere/foodguide/logic/commands/AddCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/AddCommand.java
@@ -18,7 +18,8 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an eatery to the food guide. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Adds an eatery to the food guide. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
@@ -26,12 +27,11 @@ public class AddCommand extends Command {
             + PREFIX_LOCATION + "ADDRESS "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "John Doe "
-            + PREFIX_PHONE + "98765432 "
-            + PREFIX_CUISINE + "johnd@example.com "
-            + PREFIX_LOCATION + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_NAME + "Starbucks "
+            + PREFIX_PHONE + "68160981 "
+            + PREFIX_CUISINE + "cafe "
+            + PREFIX_LOCATION + "Science Block S9 "
+            + PREFIX_TAG + "coffee ";
 
     public static final String MESSAGE_SUCCESS = "New eatery added: %1$s";
     public static final String MESSAGE_DUPLICATE_EATERY = "This eatery already exists in the food guide";

--- a/src/main/java/eatwhere/foodguide/logic/commands/ClearCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/ClearCommand.java
@@ -11,6 +11,10 @@ import eatwhere.foodguide.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Clears the food guide. ";
+
     public static final String MESSAGE_SUCCESS = "food guide has been cleared!";
 
 

--- a/src/main/java/eatwhere/foodguide/logic/commands/EditCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/EditCommand.java
@@ -43,7 +43,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
-            + PREFIX_CUISINE + "johndoe@example.com";
+            + PREFIX_CUISINE + "chinese";
 
     public static final String MESSAGE_EDIT_EATERY_SUCCESS = "Edited Eatery: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/eatwhere/foodguide/logic/commands/ListCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/ListCommand.java
@@ -11,6 +11,10 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": lists all the eateries in the food guide\n"
+            + "Example: " + COMMAND_WORD;
+
     public static final String MESSAGE_SUCCESS = "Listed all eateries";
 
 

--- a/src/main/java/eatwhere/foodguide/logic/parser/AddCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/AddCommandParser.java
@@ -30,6 +30,7 @@ public class AddCommandParser implements Parser<AddCommand> {
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
+     * @throws DisplayCommandHelpException if the user input is for displaying command help
      */
     public AddCommand parse(String args) throws ParseException, DisplayCommandHelpException {
         ArgumentMultimap argMultimap =

--- a/src/main/java/eatwhere/foodguide/logic/parser/AddCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/AddCommandParser.java
@@ -1,16 +1,18 @@
 package eatwhere.foodguide.logic.parser;
 
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_CUISINE;
+import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_HELP;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_NAME;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_PHONE;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_TAG;
+import static eatwhere.foodguide.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
 import eatwhere.foodguide.commons.core.Messages;
 import eatwhere.foodguide.logic.commands.AddCommand;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 import eatwhere.foodguide.model.eatery.Cuisine;
 import eatwhere.foodguide.model.eatery.Eatery;
@@ -29,10 +31,14 @@ public class AddCommandParser implements Parser<AddCommand> {
      * and returns an AddCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public AddCommand parse(String args) throws ParseException {
+    public AddCommand parse(String args) throws ParseException, DisplayCommandHelpException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CUISINE,
-                        PREFIX_LOCATION, PREFIX_PHONE, PREFIX_TAG);
+                        PREFIX_LOCATION, PREFIX_PHONE, PREFIX_TAG, PREFIX_HELP);
+
+        if (arePrefixesPresent(argMultimap, PREFIX_HELP)) {
+            throw new DisplayCommandHelpException(AddCommand.MESSAGE_USAGE);
+        }
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_LOCATION, PREFIX_CUISINE)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -53,14 +59,6 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
 
         return new AddCommand(eatery);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/eatwhere/foodguide/logic/parser/CliSyntax.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/CliSyntax.java
@@ -11,5 +11,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_CUISINE = new Prefix("-c");
     public static final Prefix PREFIX_LOCATION = new Prefix("-l");
     public static final Prefix PREFIX_TAG = new Prefix("-t");
+    public static final Prefix PREFIX_HELP = new Prefix("-h");
 
 }

--- a/src/main/java/eatwhere/foodguide/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/DeleteCommandParser.java
@@ -18,6 +18,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
+     * @throws DisplayCommandHelpException if the user input is for displaying command help
      */
     public DeleteCommand parse(String args) throws ParseException, DisplayCommandHelpException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_HELP);

--- a/src/main/java/eatwhere/foodguide/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/DeleteCommandParser.java
@@ -1,8 +1,12 @@
 package eatwhere.foodguide.logic.parser;
 
+import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_HELP;
+import static eatwhere.foodguide.logic.parser.ParserUtil.arePrefixesPresent;
+
 import eatwhere.foodguide.commons.core.Messages;
 import eatwhere.foodguide.commons.core.index.Index;
 import eatwhere.foodguide.logic.commands.DeleteCommand;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 
 /**
@@ -15,7 +19,13 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * and returns a DeleteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public DeleteCommand parse(String args) throws ParseException {
+    public DeleteCommand parse(String args) throws ParseException, DisplayCommandHelpException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_HELP);
+
+        if (arePrefixesPresent(argMultimap, PREFIX_HELP)) {
+            throw new DisplayCommandHelpException(DeleteCommand.MESSAGE_USAGE);
+        }
+
         try {
             Index index = ParserUtil.parseIndex(args);
             return new DeleteCommand(index);

--- a/src/main/java/eatwhere/foodguide/logic/parser/EditCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/EditCommandParser.java
@@ -30,6 +30,7 @@ public class EditCommandParser implements Parser<EditCommand> {
      * Parses the given {@code String} of arguments in the context of the EditCommand
      * and returns an EditCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
+     * @throws DisplayCommandHelpException if the user input is for displaying command help
      */
     public EditCommand parse(String args) throws ParseException, DisplayCommandHelpException {
         requireNonNull(args);

--- a/src/main/java/eatwhere/foodguide/logic/parser/EditCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/EditCommandParser.java
@@ -1,10 +1,12 @@
 package eatwhere.foodguide.logic.parser;
 
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_CUISINE;
+import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_HELP;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_NAME;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_PHONE;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_TAG;
+import static eatwhere.foodguide.logic.parser.ParserUtil.arePrefixesPresent;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
@@ -15,6 +17,7 @@ import java.util.Set;
 import eatwhere.foodguide.commons.core.Messages;
 import eatwhere.foodguide.commons.core.index.Index;
 import eatwhere.foodguide.logic.commands.EditCommand;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 import eatwhere.foodguide.model.tag.Tag;
 
@@ -28,11 +31,15 @@ public class EditCommandParser implements Parser<EditCommand> {
      * and returns an EditCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public EditCommand parse(String args) throws ParseException {
+    public EditCommand parse(String args) throws ParseException, DisplayCommandHelpException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE,
-                        PREFIX_CUISINE, PREFIX_LOCATION, PREFIX_TAG);
+                        PREFIX_CUISINE, PREFIX_LOCATION, PREFIX_TAG, PREFIX_HELP);
+
+        if (arePrefixesPresent(argMultimap, PREFIX_HELP)) {
+            throw new DisplayCommandHelpException(EditCommand.MESSAGE_USAGE);
+        }
 
         Index index;
 

--- a/src/main/java/eatwhere/foodguide/logic/parser/FindCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/FindCommandParser.java
@@ -6,7 +6,6 @@ import static eatwhere.foodguide.logic.parser.ParserUtil.arePrefixesPresent;
 import java.util.Arrays;
 
 import eatwhere.foodguide.commons.core.Messages;
-import eatwhere.foodguide.logic.commands.DeleteCommand;
 import eatwhere.foodguide.logic.commands.FindCommand;
 import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
@@ -21,12 +20,13 @@ public class FindCommandParser implements Parser<FindCommand> {
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
+     * @throws DisplayCommandHelpException if the user input is for displaying command help
      */
     public FindCommand parse(String args) throws ParseException, DisplayCommandHelpException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_HELP);
 
         if (arePrefixesPresent(argMultimap, PREFIX_HELP)) {
-            throw new DisplayCommandHelpException(DeleteCommand.MESSAGE_USAGE);
+            throw new DisplayCommandHelpException(FindCommand.MESSAGE_USAGE);
         }
 
         String trimmedArgs = args.trim();

--- a/src/main/java/eatwhere/foodguide/logic/parser/FindCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/FindCommandParser.java
@@ -1,9 +1,14 @@
 package eatwhere.foodguide.logic.parser;
 
+import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_HELP;
+import static eatwhere.foodguide.logic.parser.ParserUtil.arePrefixesPresent;
+
 import java.util.Arrays;
 
 import eatwhere.foodguide.commons.core.Messages;
+import eatwhere.foodguide.logic.commands.DeleteCommand;
 import eatwhere.foodguide.logic.commands.FindCommand;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 import eatwhere.foodguide.model.eatery.NameContainsKeywordsPredicate;
 
@@ -17,7 +22,13 @@ public class FindCommandParser implements Parser<FindCommand> {
      * and returns a FindCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public FindCommand parse(String args) throws ParseException {
+    public FindCommand parse(String args) throws ParseException, DisplayCommandHelpException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_HELP);
+
+        if (arePrefixesPresent(argMultimap, PREFIX_HELP)) {
+            throw new DisplayCommandHelpException(DeleteCommand.MESSAGE_USAGE);
+        }
+
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(

--- a/src/main/java/eatwhere/foodguide/logic/parser/FoodGuideParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/FoodGuideParser.java
@@ -34,6 +34,7 @@ public class FoodGuideParser {
      * @param userInput full user input string
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
+     * @throws DisplayCommandHelpException if the user input is for displaying command help
      */
     public Command parseCommand(String userInput) throws ParseException, DisplayCommandHelpException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());

--- a/src/main/java/eatwhere/foodguide/logic/parser/FoodGuideParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/FoodGuideParser.java
@@ -15,6 +15,7 @@ import eatwhere.foodguide.logic.commands.HelpCommand;
 import eatwhere.foodguide.logic.commands.ListCommand;
 import eatwhere.foodguide.logic.commands.TagCommand;
 import eatwhere.foodguide.logic.commands.UntagCommand;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 
 /**
@@ -34,7 +35,7 @@ public class FoodGuideParser {
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
      */
-    public Command parseCommand(String userInput) throws ParseException {
+    public Command parseCommand(String userInput) throws ParseException, DisplayCommandHelpException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
@@ -66,7 +67,7 @@ public class FoodGuideParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/eatwhere/foodguide/logic/parser/ListCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/ListCommandParser.java
@@ -1,0 +1,29 @@
+package eatwhere.foodguide.logic.parser;
+
+import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_HELP;
+import static eatwhere.foodguide.logic.parser.ParserUtil.arePrefixesPresent;
+
+import eatwhere.foodguide.logic.commands.ListCommand;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
+import eatwhere.foodguide.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ListCommand object
+ */
+public class ListCommandParser implements Parser<ListCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListCommand
+     * and returns an ListCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListCommand parse(String args) throws ParseException, DisplayCommandHelpException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_HELP);
+
+        if (arePrefixesPresent(argMultimap, PREFIX_HELP)) {
+            throw new DisplayCommandHelpException(ListCommand.MESSAGE_USAGE);
+        }
+
+        return new ListCommand();
+    }
+}

--- a/src/main/java/eatwhere/foodguide/logic/parser/ListCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/ListCommandParser.java
@@ -16,6 +16,7 @@ public class ListCommandParser implements Parser<ListCommand> {
      * Parses the given {@code String} of arguments in the context of the ListCommand
      * and returns an ListCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
+     * @throws DisplayCommandHelpException if the user input is for displaying command help
      */
     public ListCommand parse(String args) throws ParseException, DisplayCommandHelpException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_HELP);

--- a/src/main/java/eatwhere/foodguide/logic/parser/Parser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/Parser.java
@@ -1,6 +1,7 @@
 package eatwhere.foodguide.logic.parser;
 
 import eatwhere.foodguide.logic.commands.Command;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 
 /**
@@ -12,5 +13,5 @@ public interface Parser<T extends Command> {
      * Parses {@code userInput} into a command and returns it.
      * @throws ParseException if {@code userInput} does not conform the expected format
      */
-    T parse(String userInput) throws ParseException;
+    T parse(String userInput) throws ParseException, DisplayCommandHelpException;
 }

--- a/src/main/java/eatwhere/foodguide/logic/parser/Parser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/Parser.java
@@ -12,6 +12,7 @@ public interface Parser<T extends Command> {
     /**
      * Parses {@code userInput} into a command and returns it.
      * @throws ParseException if {@code userInput} does not conform the expected format
+     * @throws DisplayCommandHelpException for {@code userInput} intended to display command help
      */
     T parse(String userInput) throws ParseException, DisplayCommandHelpException;
 }

--- a/src/main/java/eatwhere/foodguide/logic/parser/ParserUtil.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/ParserUtil.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import eatwhere.foodguide.commons.core.index.Index;
 import eatwhere.foodguide.commons.util.StringUtil;
@@ -120,5 +121,13 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/eatwhere/foodguide/logic/parser/TagCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/TagCommandParser.java
@@ -25,6 +25,7 @@ public class TagCommandParser implements Parser<TagCommand> {
      * Parses the given {@code String} of arguments in the context of the TagCommand
      * and returns an TagCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
+     * @throws DisplayCommandHelpException if the user input is for displaying command help
      */
     public TagCommand parse(String args) throws ParseException, DisplayCommandHelpException {
         requireNonNull(args);

--- a/src/main/java/eatwhere/foodguide/logic/parser/TagCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/TagCommandParser.java
@@ -1,6 +1,8 @@
 package eatwhere.foodguide.logic.parser;
 
+import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_HELP;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_TAG;
+import static eatwhere.foodguide.logic.parser.ParserUtil.arePrefixesPresent;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
@@ -10,6 +12,7 @@ import java.util.Set;
 import eatwhere.foodguide.commons.core.Messages;
 import eatwhere.foodguide.commons.core.index.Index;
 import eatwhere.foodguide.logic.commands.TagCommand;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 import eatwhere.foodguide.model.tag.Tag;
 
@@ -23,10 +26,14 @@ public class TagCommandParser implements Parser<TagCommand> {
      * and returns an TagCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public TagCommand parse(String args) throws ParseException {
+    public TagCommand parse(String args) throws ParseException, DisplayCommandHelpException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_TAG, PREFIX_HELP);
+
+        if (arePrefixesPresent(argMultimap, PREFIX_HELP)) {
+            throw new DisplayCommandHelpException(TagCommand.MESSAGE_USAGE);
+        }
 
         Index index;
 

--- a/src/main/java/eatwhere/foodguide/logic/parser/UntagCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/UntagCommandParser.java
@@ -1,6 +1,8 @@
 package eatwhere.foodguide.logic.parser;
 
+import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_HELP;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_TAG;
+import static eatwhere.foodguide.logic.parser.ParserUtil.arePrefixesPresent;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
@@ -10,6 +12,7 @@ import java.util.Set;
 import eatwhere.foodguide.commons.core.Messages;
 import eatwhere.foodguide.commons.core.index.Index;
 import eatwhere.foodguide.logic.commands.UntagCommand;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 import eatwhere.foodguide.model.tag.Tag;
 
@@ -23,10 +26,14 @@ public class UntagCommandParser implements Parser<UntagCommand> {
      * and returns an UntagCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public UntagCommand parse(String args) throws ParseException {
+    public UntagCommand parse(String args) throws ParseException, DisplayCommandHelpException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_TAG, PREFIX_HELP);
+
+        if (arePrefixesPresent(argMultimap, PREFIX_HELP)) {
+            throw new DisplayCommandHelpException(UntagCommand.MESSAGE_USAGE);
+        }
 
         Index index;
 

--- a/src/main/java/eatwhere/foodguide/logic/parser/UntagCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/UntagCommandParser.java
@@ -25,6 +25,7 @@ public class UntagCommandParser implements Parser<UntagCommand> {
      * Parses the given {@code String} of arguments in the context of the UntagCommand
      * and returns an UntagCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
+     * @throws DisplayCommandHelpException if the user input is for displaying command help
      */
     public UntagCommand parse(String args) throws ParseException, DisplayCommandHelpException {
         requireNonNull(args);

--- a/src/main/java/eatwhere/foodguide/logic/parser/exceptions/DisplayCommandHelpException.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/exceptions/DisplayCommandHelpException.java
@@ -1,0 +1,16 @@
+package eatwhere.foodguide.logic.parser.exceptions;
+
+/**
+ * Represents a call to display the help message of a command
+ * for supported commands.
+ */
+public class DisplayCommandHelpException extends Exception {
+
+    public DisplayCommandHelpException(String message) {
+        super(message);
+    }
+
+    public DisplayCommandHelpException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/eatwhere/foodguide/ui/CommandBox.java
+++ b/src/main/java/eatwhere/foodguide/ui/CommandBox.java
@@ -3,6 +3,7 @@ package eatwhere.foodguide.ui;
 import eatwhere.foodguide.logic.Logic;
 import eatwhere.foodguide.logic.commands.CommandResult;
 import eatwhere.foodguide.logic.commands.exceptions.CommandException;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
@@ -47,6 +48,8 @@ public class CommandBox extends UiPart<Region> {
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
+        } catch (DisplayCommandHelpException e) {
+            setStyleToDefault();
         }
     }
 
@@ -80,7 +83,7 @@ public class CommandBox extends UiPart<Region> {
          *
          * @see Logic#execute(String)
          */
-        CommandResult execute(String commandText) throws CommandException, ParseException;
+        CommandResult execute(String commandText) throws CommandException, ParseException, DisplayCommandHelpException;
     }
 
 }

--- a/src/main/java/eatwhere/foodguide/ui/MainWindow.java
+++ b/src/main/java/eatwhere/foodguide/ui/MainWindow.java
@@ -7,6 +7,7 @@ import eatwhere.foodguide.commons.core.LogsCenter;
 import eatwhere.foodguide.logic.Logic;
 import eatwhere.foodguide.logic.commands.CommandResult;
 import eatwhere.foodguide.logic.commands.exceptions.CommandException;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
@@ -172,7 +173,8 @@ public class MainWindow extends UiPart<Stage> {
      *
      * @see Logic#execute(String)
      */
-    private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
+    private CommandResult executeCommand(String commandText) throws CommandException, ParseException,
+            DisplayCommandHelpException {
         try {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
@@ -187,6 +189,10 @@ public class MainWindow extends UiPart<Stage> {
             }
 
             return commandResult;
+        } catch (DisplayCommandHelpException e) {
+            logger.info("Displaying help: " + commandText);
+            resultDisplay.setFeedbackToUser(e.getMessage());
+            throw e;
         } catch (CommandException | ParseException e) {
             logger.info("Invalid command: " + commandText);
             resultDisplay.setFeedbackToUser(e.getMessage());

--- a/src/test/java/eatwhere/foodguide/logic/LogicManagerTest.java
+++ b/src/test/java/eatwhere/foodguide/logic/LogicManagerTest.java
@@ -16,6 +16,7 @@ import eatwhere.foodguide.logic.commands.CommandResult;
 import eatwhere.foodguide.logic.commands.CommandTestUtil;
 import eatwhere.foodguide.logic.commands.ListCommand;
 import eatwhere.foodguide.logic.commands.exceptions.CommandException;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 import eatwhere.foodguide.model.Model;
 import eatwhere.foodguide.model.ModelManager;
@@ -99,7 +100,7 @@ public class LogicManagerTest {
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertCommandSuccess(String inputCommand, String expectedMessage,
-            Model expectedModel) throws CommandException, ParseException {
+            Model expectedModel) throws CommandException, ParseException, DisplayCommandHelpException {
         CommandResult result = logic.execute(inputCommand);
         assertEquals(expectedMessage, result.getFeedbackToUser());
         assertEquals(expectedModel, model);

--- a/src/test/java/eatwhere/foodguide/logic/commands/CommandTestUtil.java
+++ b/src/test/java/eatwhere/foodguide/logic/commands/CommandTestUtil.java
@@ -1,6 +1,7 @@
 package eatwhere.foodguide.logic.commands;
 
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_CUISINE;
+import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_HELP;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_NAME;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -47,6 +48,7 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_LOCATION + VALID_ADDRESS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String HELP_DESC = " " + PREFIX_HELP;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones

--- a/src/test/java/eatwhere/foodguide/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/eatwhere/foodguide/logic/parser/AddCommandParserTest.java
@@ -158,4 +158,20 @@ public class AddCommandParserTest {
                         + CommandTestUtil.TAG_DESC_FRIEND,
                         String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_displayHelp_success() {
+        // only preamble and help prefix
+        CommandParserTestUtil.assertParseDisplayCommandHelp(parser,
+                CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.HELP_DESC,
+                AddCommand.MESSAGE_USAGE);
+
+        // fields present and help prefix also present
+        CommandParserTestUtil.assertParseDisplayCommandHelp(parser,
+                CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB
+                        + CommandTestUtil.CUISINE_DESC_BOB + CommandTestUtil.ADDRESS_DESC_BOB
+                        + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND
+                        + CommandTestUtil.HELP_DESC,
+                        AddCommand.MESSAGE_USAGE);
+    }
 }

--- a/src/test/java/eatwhere/foodguide/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/eatwhere/foodguide/logic/parser/CommandParserTestUtil.java
@@ -3,6 +3,7 @@ package eatwhere.foodguide.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import eatwhere.foodguide.logic.commands.Command;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 
 /**
@@ -19,8 +20,10 @@ public class CommandParserTestUtil {
         try {
             Command command = parser.parse(userInput);
             assertEquals(expectedCommand, command);
-        } catch (ParseException pe) {
-            throw new IllegalArgumentException("Invalid userInput.", pe);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("Invalid userInput.", e);
+        } catch (DisplayCommandHelpException e){
+            throw new AssertionError("A DisplayCommandHelpException was unexpectedly thrown.");
         }
     }
 
@@ -32,8 +35,26 @@ public class CommandParserTestUtil {
         try {
             parser.parse(userInput);
             throw new AssertionError("The expected ParseException was not thrown.");
-        } catch (ParseException pe) {
-            assertEquals(expectedMessage, pe.getMessage());
+        } catch (ParseException e) {
+            assertEquals(expectedMessage, e.getMessage());
+        } catch (DisplayCommandHelpException e) {
+            throw new AssertionError("The expected ParseException was not thrown.");
+        }
+    }
+
+    /**
+     * Asserts that the parsing of {@code userInput} by {@code parser} results in a command help
+     * being displayed with message equal to {@code expectedMessage}.
+     */
+    public static void assertParseDisplayCommandHelp(Parser<? extends Command> parser,
+                                                     String userInput, String expectedMessage) {
+        try {
+            parser.parse(userInput);
+            throw new AssertionError("The expected DisplayCommandHelpException was not thrown.");
+        } catch (DisplayCommandHelpException e) {
+            assertEquals(expectedMessage, e.getMessage());
+        } catch (ParseException e) {
+            throw new AssertionError("The expected DisplayCommandHelpException was not thrown.");
         }
     }
 }

--- a/src/test/java/eatwhere/foodguide/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/eatwhere/foodguide/logic/parser/CommandParserTestUtil.java
@@ -22,7 +22,7 @@ public class CommandParserTestUtil {
             assertEquals(expectedCommand, command);
         } catch (ParseException e) {
             throw new IllegalArgumentException("Invalid userInput.", e);
-        } catch (DisplayCommandHelpException e){
+        } catch (DisplayCommandHelpException e) {
             throw new AssertionError("A DisplayCommandHelpException was unexpectedly thrown.");
         }
     }

--- a/src/test/java/eatwhere/foodguide/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/eatwhere/foodguide/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,7 @@
 package eatwhere.foodguide.logic.parser;
 
 import static eatwhere.foodguide.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static eatwhere.foodguide.logic.commands.CommandTestUtil.HELP_DESC;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,5 +28,15 @@ public class DeleteCommandParserTest {
     public void parse_invalidArgs_throwsParseException() {
         CommandParserTestUtil.assertParseFailure(parser, "a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_displayHelp_success() {
+        // only help parameter
+        CommandParserTestUtil.assertParseDisplayCommandHelp(parser, HELP_DESC, DeleteCommand.MESSAGE_USAGE);
+
+        // help parameter overrides index
+        CommandParserTestUtil.assertParseDisplayCommandHelp(parser, "1" + HELP_DESC,
+                DeleteCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/eatwhere/foodguide/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/eatwhere/foodguide/logic/parser/EditCommandParserTest.java
@@ -1,6 +1,7 @@
 package eatwhere.foodguide.logic.parser;
 
 import static eatwhere.foodguide.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static eatwhere.foodguide.logic.commands.CommandTestUtil.HELP_DESC;
 import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_TAG;
 
 import org.junit.jupiter.api.Test;
@@ -214,5 +215,13 @@ public class EditCommandParserTest {
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         CommandParserTestUtil.assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_displayHelp_success() {
+        Index targetIndex = TypicalIndexes.INDEX_THIRD_EATERY;
+        String userInput = targetIndex.getOneBased() + HELP_DESC;
+
+        CommandParserTestUtil.assertParseDisplayCommandHelp(parser, userInput, EditCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/eatwhere/foodguide/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/eatwhere/foodguide/logic/parser/EditCommandParserTest.java
@@ -223,5 +223,13 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + HELP_DESC;
 
         CommandParserTestUtil.assertParseDisplayCommandHelp(parser, userInput, EditCommand.MESSAGE_USAGE);
+
+        // help prefix overrides normal edit command behavior
+        userInput = targetIndex.getOneBased()
+                + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.TAG_DESC_HUSBAND
+                + CommandTestUtil.CUISINE_DESC_AMY + CommandTestUtil.ADDRESS_DESC_AMY
+                + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.TAG_DESC_FRIEND + HELP_DESC;
+
+        CommandParserTestUtil.assertParseDisplayCommandHelp(parser, userInput, EditCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/eatwhere/foodguide/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/eatwhere/foodguide/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,7 @@
 package eatwhere.foodguide.logic.parser;
 
 import static eatwhere.foodguide.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static eatwhere.foodguide.logic.commands.CommandTestUtil.HELP_DESC;
 
 import java.util.Arrays;
 
@@ -30,4 +31,14 @@ public class FindCommandParserTest {
         CommandParserTestUtil.assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
     }
 
+    @Test
+    public void parse_displayHelp_success() {
+        // only help prefix
+        CommandParserTestUtil.assertParseDisplayCommandHelp(parser,
+                HELP_DESC, FindCommand.MESSAGE_USAGE);
+
+        // help prefix overrides keywords
+        CommandParserTestUtil.assertParseDisplayCommandHelp(parser,
+                "Alice Bob" + HELP_DESC, FindCommand.MESSAGE_USAGE);
+    }
 }

--- a/src/test/java/eatwhere/foodguide/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/eatwhere/foodguide/logic/parser/ListCommandParserTest.java
@@ -1,0 +1,17 @@
+package eatwhere.foodguide.logic.parser;
+
+import static eatwhere.foodguide.logic.commands.CommandTestUtil.HELP_DESC;
+
+import org.junit.jupiter.api.Test;
+
+import eatwhere.foodguide.logic.commands.ListCommand;
+
+public class ListCommandParserTest {
+
+    private ListCommandParser parser = new ListCommandParser();
+
+    @Test
+    public void parse_displayHelp_success() {
+        CommandParserTestUtil.assertParseDisplayCommandHelp(parser, HELP_DESC, ListCommand.MESSAGE_USAGE);
+    }
+}


### PR DESCRIPTION
Currently, information for how to input commands is located only in the help window and user guide. Both of these are rather inconvenient to a user as they use a separate window.

In order to streamline the CLI usage process, I propose to add a new parameter "-h" which, instead of processing the command,
returns the usage string for the command. This is similar to other CLI programs such as ffmpeg or pip.

To achieve this, the command is scanned for the help prefix. If the prefix is present, execution is hijacked via throwing an exception in the parser. This may not be the most appropriate way to do things, but it avoids creating new constructors for each command in order to return new instances of them (because of the interface Parser).

This functionality is currently added for add, delete, edit, find and list, tag and untag commands. I presume it is unnecessary for clear and exit commands. I am unsure whether it should be added for the clear command (but can easily do so if it is part of the final specification).