### PR TITLE
Add help prefix support to find by tag and location

### DIFF
--- a/src/main/java/eatwhere/foodguide/logic/parser/FindLocationCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/FindLocationCommandParser.java
@@ -1,14 +1,18 @@
 package eatwhere.foodguide.logic.parser;
 
+import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_HELP;
+import static eatwhere.foodguide.logic.parser.ParserUtil.arePrefixesPresent;
+
 import java.util.Arrays;
 
 import eatwhere.foodguide.commons.core.Messages;
 import eatwhere.foodguide.logic.commands.FindLocationCommand;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 import eatwhere.foodguide.model.eatery.LocationContainsKeywordsPredicate;
 
 /**
- * Parses input arguments and creates a new FindCommand object
+ * Parses input arguments and creates a new FindLocationCommand object
  */
 public class FindLocationCommandParser implements Parser<FindLocationCommand> {
 
@@ -16,8 +20,15 @@ public class FindLocationCommandParser implements Parser<FindLocationCommand> {
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
+     * @throws DisplayCommandHelpException if the user input is for displaying command help
      */
-    public FindLocationCommand parse(String args) throws ParseException {
+    public FindLocationCommand parse(String args) throws ParseException, DisplayCommandHelpException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_HELP);
+
+        if (arePrefixesPresent(argMultimap, PREFIX_HELP)) {
+            throw new DisplayCommandHelpException(FindLocationCommand.MESSAGE_USAGE);
+        }
+
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(

--- a/src/main/java/eatwhere/foodguide/logic/parser/FindTagCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/FindTagCommandParser.java
@@ -1,14 +1,18 @@
 package eatwhere.foodguide.logic.parser;
 
+import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_HELP;
+import static eatwhere.foodguide.logic.parser.ParserUtil.arePrefixesPresent;
+
 import java.util.Arrays;
 
 import eatwhere.foodguide.commons.core.Messages;
 import eatwhere.foodguide.logic.commands.FindTagCommand;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
 import eatwhere.foodguide.logic.parser.exceptions.ParseException;
 import eatwhere.foodguide.model.eatery.TagsContainsKeywordsPredicate;
 
 /**
- * Parses input arguments and creates a new FindCommand object
+ * Parses input arguments and creates a new FindTagCommand object
  */
 public class FindTagCommandParser implements Parser<FindTagCommand> {
 
@@ -16,8 +20,15 @@ public class FindTagCommandParser implements Parser<FindTagCommand> {
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
+     * @throws DisplayCommandHelpException if the user input is for displaying command help
      */
-    public FindTagCommand parse(String args) throws ParseException {
+    public FindTagCommand parse(String args) throws ParseException, DisplayCommandHelpException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_HELP);
+
+        if (arePrefixesPresent(argMultimap, PREFIX_HELP)) {
+            throw new DisplayCommandHelpException(FindTagCommand.MESSAGE_USAGE);
+        }
+
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(

--- a/src/main/java/eatwhere/foodguide/model/util/SampleDataUtil.java
+++ b/src/main/java/eatwhere/foodguide/model/util/SampleDataUtil.java
@@ -30,7 +30,7 @@ public class SampleDataUtil {
                 getTagSet("foodcourt")),
             new Eatery(new Name("The Deck"), new Phone(""), new Cuisine("variety"),
                 new Location("Faculty of Arts & Social Sciences"),
-                getTagSet("fodocourt")),
+                getTagSet("foodcourt")),
             new Eatery(new Name("KOI"), new Phone("69933323"), new Cuisine("bubble tea"),
                 new Location("Central Square"),
                 getTagSet()),

--- a/src/test/java/eatwhere/foodguide/logic/parser/FindLocationCommandParserTest.java
+++ b/src/test/java/eatwhere/foodguide/logic/parser/FindLocationCommandParserTest.java
@@ -1,0 +1,44 @@
+package eatwhere.foodguide.logic.parser;
+
+
+import static eatwhere.foodguide.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static eatwhere.foodguide.logic.commands.CommandTestUtil.HELP_DESC;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import eatwhere.foodguide.logic.commands.FindLocationCommand;
+import eatwhere.foodguide.model.eatery.LocationContainsKeywordsPredicate;
+
+public class FindLocationCommandParserTest {
+    private FindLocationCommandParser parser = new FindLocationCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        CommandParserTestUtil.assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindLocationCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FindLocationCommand expectedFindLocationCommand =
+                new FindLocationCommand(new LocationContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+        CommandParserTestUtil.assertParseSuccess(parser, "Alice Bob", expectedFindLocationCommand);
+
+        // multiple whitespaces between keywords
+        CommandParserTestUtil.assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindLocationCommand);
+    }
+
+    @Test
+    public void parse_displayHelp_success() {
+        // only help prefix
+        CommandParserTestUtil.assertParseDisplayCommandHelp(parser,
+                HELP_DESC, FindLocationCommand.MESSAGE_USAGE);
+
+        // help prefix overrides keywords
+        CommandParserTestUtil.assertParseDisplayCommandHelp(parser,
+                "Alice Bob" + HELP_DESC, FindLocationCommand.MESSAGE_USAGE);
+    }
+}

--- a/src/test/java/eatwhere/foodguide/logic/parser/FindTagCommandParserTest.java
+++ b/src/test/java/eatwhere/foodguide/logic/parser/FindTagCommandParserTest.java
@@ -1,0 +1,43 @@
+package eatwhere.foodguide.logic.parser;
+
+import static eatwhere.foodguide.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static eatwhere.foodguide.logic.commands.CommandTestUtil.HELP_DESC;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import eatwhere.foodguide.logic.commands.FindTagCommand;
+import eatwhere.foodguide.model.eatery.TagsContainsKeywordsPredicate;
+
+public class FindTagCommandParserTest {
+    private FindTagCommandParser parser = new FindTagCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        CommandParserTestUtil.assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindTagCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FindTagCommand expectedFindTagCommand =
+                new FindTagCommand(new TagsContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+        CommandParserTestUtil.assertParseSuccess(parser, "Alice Bob", expectedFindTagCommand);
+
+        // multiple whitespaces between keywords
+        CommandParserTestUtil.assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindTagCommand);
+    }
+
+    @Test
+    public void parse_displayHelp_success() {
+        // only help prefix
+        CommandParserTestUtil.assertParseDisplayCommandHelp(parser,
+                HELP_DESC, FindTagCommand.MESSAGE_USAGE);
+
+        // help prefix overrides keywords
+        CommandParserTestUtil.assertParseDisplayCommandHelp(parser,
+                "Alice Bob" + HELP_DESC, FindTagCommand.MESSAGE_USAGE);
+    }
+}


### PR DESCRIPTION
Support for the help parameter (currently: -h) is added to the new findTag and findLocation commands.
Test methods mirroring those of the find command are also added.

A minor typo in the current default eatery data list is also fixed.