### PR TITLE
add findCuisine command

### DIFF
--- a/src/main/java/eatwhere/foodguide/logic/commands/FindCuisineCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/FindCuisineCommand.java
@@ -1,0 +1,42 @@
+package eatwhere.foodguide.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import eatwhere.foodguide.commons.core.Messages;
+import eatwhere.foodguide.model.Model;
+import eatwhere.foodguide.model.eatery.CuisineContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all eateries in food guide whose tags contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FindCuisineCommand extends Command {
+
+    public static final String COMMAND_WORD = "findCuisine";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all eateries whose cuisine matches any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " mala";
+
+    private final CuisineContainsKeywordsPredicate predicate;
+
+    public FindCuisineCommand(CuisineContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredEateryList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_EATERIES_LISTED_OVERVIEW, model.getFilteredEateryList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindCuisineCommand // instanceof handles nulls
+                && predicate.equals(((FindCuisineCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/eatwhere/foodguide/logic/parser/FindCuisineCommandParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/FindCuisineCommandParser.java
@@ -1,0 +1,43 @@
+package eatwhere.foodguide.logic.parser;
+
+import static eatwhere.foodguide.logic.parser.CliSyntax.PREFIX_HELP;
+import static eatwhere.foodguide.logic.parser.ParserUtil.arePrefixesPresent;
+
+import java.util.Arrays;
+
+import eatwhere.foodguide.commons.core.Messages;
+import eatwhere.foodguide.logic.commands.FindCuisineCommand;
+import eatwhere.foodguide.logic.parser.exceptions.DisplayCommandHelpException;
+import eatwhere.foodguide.logic.parser.exceptions.ParseException;
+import eatwhere.foodguide.model.eatery.CuisineContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindLocationCommand object
+ */
+public class FindCuisineCommandParser implements Parser<FindCuisineCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     * @throws DisplayCommandHelpException if the user input is for displaying command help
+     */
+    public FindCuisineCommand parse(String args) throws ParseException, DisplayCommandHelpException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_HELP);
+
+        if (arePrefixesPresent(argMultimap, PREFIX_HELP)) {
+            throw new DisplayCommandHelpException(FindCuisineCommand.MESSAGE_USAGE);
+        }
+
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, FindCuisineCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindCuisineCommand(new CuisineContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/eatwhere/foodguide/logic/parser/FoodGuideParser.java
+++ b/src/main/java/eatwhere/foodguide/logic/parser/FoodGuideParser.java
@@ -11,6 +11,7 @@ import eatwhere.foodguide.logic.commands.DeleteCommand;
 import eatwhere.foodguide.logic.commands.EditCommand;
 import eatwhere.foodguide.logic.commands.ExitCommand;
 import eatwhere.foodguide.logic.commands.FindCommand;
+import eatwhere.foodguide.logic.commands.FindCuisineCommand;
 import eatwhere.foodguide.logic.commands.FindLocationCommand;
 import eatwhere.foodguide.logic.commands.FindTagCommand;
 import eatwhere.foodguide.logic.commands.HelpCommand;
@@ -80,6 +81,9 @@ public class FoodGuideParser {
 
         case FindTagCommand.COMMAND_WORD:
             return new FindTagCommandParser().parse(arguments);
+
+        case FindCuisineCommand.COMMAND_WORD:
+            return new FindCuisineCommandParser().parse(arguments);
 
         case FindLocationCommand.COMMAND_WORD:
             return new FindLocationCommandParser().parse(arguments);

--- a/src/main/java/eatwhere/foodguide/model/eatery/CuisineContainsKeywordsPredicate.java
+++ b/src/main/java/eatwhere/foodguide/model/eatery/CuisineContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package eatwhere.foodguide.model.eatery;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import eatwhere.foodguide.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Eatery}'s {@code cuisine} matches any of the keywords given.
+ */
+public class CuisineContainsKeywordsPredicate implements Predicate<Eatery> {
+    private final List<String> keywords;
+
+    public CuisineContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Eatery eatery) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(eatery.getCuisine().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CuisineContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((CuisineContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}


### PR DESCRIPTION
Added `findCuisine` command.

If multiple cuisines are inputs (e.g. `findCuisine snacks variety chinese`), eateries of all 3 cuisines will be listed.

Help prefix works with this command as well, i.e. `findCuisine -h`.