### PR TITLE
Update message usages to match User Guide

### DIFF
--- a/src/main/java/eatwhere/foodguide/logic/commands/AddCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/AddCommand.java
@@ -22,7 +22,7 @@ public class AddCommand extends Command {
             + ": Adds an eatery to the food guide. "
             + "Parameters: "
             + PREFIX_NAME + " NAME "
-            + PREFIX_PRICE + " PRICE "
+            + "[" + PREFIX_PRICE + " PRICE] "
             + PREFIX_CUISINE + " CUISINE "
             + PREFIX_LOCATION + " LOCATION "
             + "[" + PREFIX_TAG + " TAG]...\n"

--- a/src/main/java/eatwhere/foodguide/logic/commands/AddCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/AddCommand.java
@@ -21,17 +21,17 @@ public class AddCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds an eatery to the food guide. "
             + "Parameters: "
-            + PREFIX_NAME + "NAME "
-            + PREFIX_PRICE + "PRICE "
-            + PREFIX_CUISINE + "CUISINE "
-            + PREFIX_LOCATION + "LOCATION "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + PREFIX_NAME + " NAME "
+            + PREFIX_PRICE + " PRICE "
+            + PREFIX_CUISINE + " CUISINE "
+            + PREFIX_LOCATION + " LOCATION "
+            + "[" + PREFIX_TAG + " TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "Starbucks "
-            + PREFIX_PRICE + "$$$ "
-            + PREFIX_CUISINE + "cafe "
-            + PREFIX_LOCATION + "Science Block S9 "
-            + PREFIX_TAG + "coffee ";
+            + PREFIX_NAME + " Starbucks "
+            + PREFIX_PRICE + " $$$ "
+            + PREFIX_CUISINE + " cafe "
+            + PREFIX_LOCATION + " Science Block S9 "
+            + PREFIX_TAG + " coffee ";
 
     public static final String MESSAGE_SUCCESS = "New eatery added: %1$s";
     public static final String MESSAGE_DUPLICATE_EATERY = "This eatery already exists in the food guide";

--- a/src/main/java/eatwhere/foodguide/logic/commands/EditCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/EditCommand.java
@@ -36,14 +36,14 @@ public class EditCommand extends Command {
             + "by the index number used in the displayed eatery list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_NAME + "NAME] "
-            + "[" + PREFIX_PRICE + "PHONE] "
-            + "[" + PREFIX_CUISINE + "EMAIL] "
-            + "[" + PREFIX_LOCATION + "ADDRESS] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_NAME + " NAME] "
+            + "[" + PREFIX_PRICE + " PHONE] "
+            + "[" + PREFIX_CUISINE + " EMAIL] "
+            + "[" + PREFIX_LOCATION + " ADDRESS] "
+            + "[" + PREFIX_TAG + " TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_PRICE + "91234567 "
-            + PREFIX_CUISINE + "chinese";
+            + PREFIX_PRICE + " 91234567 "
+            + PREFIX_CUISINE + " chinese";
 
     public static final String MESSAGE_EDIT_EATERY_SUCCESS = "Edited Eatery: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/eatwhere/foodguide/logic/commands/FindCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/FindCommand.java
@@ -23,7 +23,7 @@ public class FindCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all eateries whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Optionally, you can randomly choose a given number of the found eateries.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]... -r [NUMTOSHOW]\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]... [-r NUMTOSHOW]\n"
             + "Example: " + COMMAND_WORD + " Chicken Rice -r 1";
 
     private final Predicate<Eatery> predicate;

--- a/src/main/java/eatwhere/foodguide/logic/commands/FindCuisineCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/FindCuisineCommand.java
@@ -22,7 +22,7 @@ public class FindCuisineCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all eateries whose cuisine matches any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]... -r <INT>\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]... [-r <INT>]\n"
             + "Example: " + COMMAND_WORD + " mala -r 1";
 
     private final Predicate<Eatery> predicate;

--- a/src/main/java/eatwhere/foodguide/logic/commands/FindLocationCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/FindLocationCommand.java
@@ -22,7 +22,7 @@ public class FindLocationCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all eateries whose location matches any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]... -r <INT>\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]... [-r NUMTOSHOW]\n"
             + "Example: " + COMMAND_WORD + " The Deck -r 1";
 
     private final Predicate<Eatery> predicate;

--- a/src/main/java/eatwhere/foodguide/logic/commands/FindPriceCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/FindPriceCommand.java
@@ -21,7 +21,7 @@ public class FindPriceCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all eatries whose price matches "
             + "the specified keywords and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...-r <INT>\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]... [-r NUMTOSHOW]\n"
             + "Example: " + COMMAND_WORD + " $$ -r 1";
 
 

--- a/src/main/java/eatwhere/foodguide/logic/commands/FindTagCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/FindTagCommand.java
@@ -22,7 +22,7 @@ public class FindTagCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all eateries whose list of tags matches any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...-r <INT>\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]... [-r NUMTOSHOW]\n"
             + "Example: " + COMMAND_WORD + " vegetarian -r 1";
 
     private final Predicate<Eatery> predicate;

--- a/src/main/java/eatwhere/foodguide/logic/commands/TagCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/TagCommand.java
@@ -28,7 +28,7 @@ public class TagCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds tags to the eatery identified "
             + "by the index number used in the displayed eatery list.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_TAG + " TAG]...\n"
+            + "" + PREFIX_TAG + " TAG1 " + "[" + PREFIX_TAG + " TAG2]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_TAG + " halal";
 

--- a/src/main/java/eatwhere/foodguide/logic/commands/TagCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/TagCommand.java
@@ -28,9 +28,9 @@ public class TagCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds tags to the eatery identified "
             + "by the index number used in the displayed eatery list.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + " TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_TAG + "halal";
+            + PREFIX_TAG + " halal";
 
     /**
      *  %1$s - s if multiple tags, else nothing (i.e. tags or tag)

--- a/src/main/java/eatwhere/foodguide/logic/commands/UntagCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/UntagCommand.java
@@ -28,7 +28,7 @@ public class UntagCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Removes tags of the eatery identified "
             + "by the index number used in the displayed eatery list.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_TAG + " TAG]...\n"
+            + "" + PREFIX_TAG + " TAG1" + " [" + PREFIX_TAG + " TAG2]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_TAG + " halal";
 

--- a/src/main/java/eatwhere/foodguide/logic/commands/UntagCommand.java
+++ b/src/main/java/eatwhere/foodguide/logic/commands/UntagCommand.java
@@ -28,9 +28,9 @@ public class UntagCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Removes tags of the eatery identified "
             + "by the index number used in the displayed eatery list.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + " TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_TAG + "halal";
+            + PREFIX_TAG + " halal";
 
     /**
      *  %1$s - s if multiple tags, else nothing (i.e. tags or tag)


### PR DESCRIPTION
Fixes #142 #134 #131

Spacings are added between prefixes and parameters i.e. -thalal is changed to -t halal
to make the usages clearer.
This matches the current user guide.