### PR TITLE
Added test cases for containsKeywordsPredicate classes

### DIFF
--- a/src/test/java/eatwhere/foodguide/model/eatery/LocationContainsKeywordsPredicateTest.java
+++ b/src/test/java/eatwhere/foodguide/model/eatery/LocationContainsKeywordsPredicateTest.java
@@ -1,0 +1,79 @@
+package eatwhere.foodguide.model.eatery;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import eatwhere.foodguide.testutil.EateryBuilder;
+
+public class LocationContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("firstLocation");
+        List<String> secondPredicateKeywordList = Arrays.asList("firstLocation", "secondLocation");
+
+        LocationContainsKeywordsPredicate firstPredicate =
+                new LocationContainsKeywordsPredicate(firstPredicateKeywordList);
+        LocationContainsKeywordsPredicate secondPredicate =
+                new LocationContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        LocationContainsKeywordsPredicate firstPredicateCopy =
+                new LocationContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different eatery -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_locationContainsKeywords_returnsTrue() {
+        // One keyword
+        LocationContainsKeywordsPredicate predicate =
+                new LocationContainsKeywordsPredicate(Collections.singletonList("NUS"));
+        assertTrue(predicate.test(new EateryBuilder().withLocation("NUS Computing").build()));
+
+        // Multiple keywords
+        predicate = new LocationContainsKeywordsPredicate(Arrays.asList("NUS", "Computing"));
+        assertTrue(predicate.test(new EateryBuilder().withLocation("NUS Computing").build()));
+
+        // Only one matching keyword
+        predicate = new LocationContainsKeywordsPredicate(Arrays.asList("Computing", "Science"));
+        assertTrue(predicate.test(new EateryBuilder().withLocation("NUS Science").build()));
+
+        // Mixed-case keywords
+        predicate = new LocationContainsKeywordsPredicate(Arrays.asList("Nus", "COMPUTING"));
+        assertTrue(predicate.test(new EateryBuilder().withLocation("NUS Computing").build()));
+    }
+
+    @Test
+    public void test_locationDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        LocationContainsKeywordsPredicate predicate = new LocationContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new EateryBuilder().withLocation("NUS").build()));
+
+        // Non-matching keyword
+        predicate = new LocationContainsKeywordsPredicate(Arrays.asList("Science"));
+        assertFalse(predicate.test(new EateryBuilder().withLocation("NUS Computing").build()));
+
+        // Keywords match other fields, but does not match location
+        predicate = new LocationContainsKeywordsPredicate(Arrays.asList("$$", "Chinese", "Eatery"));
+        assertFalse(predicate.test(new EateryBuilder().withName("Eatery").withPrice("$$")
+                .withCuisine("Chinese").withLocation("NUS").build()));
+    }
+}

--- a/src/test/java/eatwhere/foodguide/model/eatery/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/eatwhere/foodguide/model/eatery/NameContainsKeywordsPredicateTest.java
@@ -67,10 +67,9 @@ public class NameContainsKeywordsPredicateTest {
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"));
         assertFalse(predicate.test(new EateryBuilder().withName("Alice Bob").build()));
 
-        // Keywords match phone, email and address, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("$$", "aliceemailcom", "Main", "Street"));
-        assertFalse(predicate.test(new EateryBuilder().withName("Alice").withPrice("$$")
-                .withCuisine("aliceemailcom").withLocation("Main Street").build()));
-
+        // Keywords match other fields, but does not match name
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("$$", "Chinese", "NUS"));
+        assertFalse(predicate.test(new EateryBuilder().withName("Eatery").withPrice("$$")
+                .withCuisine("Chinese").withLocation("NUS").build()));
     }
 }

--- a/src/test/java/eatwhere/foodguide/model/eatery/PriceContainsKeywordsPredicateTest.java
+++ b/src/test/java/eatwhere/foodguide/model/eatery/PriceContainsKeywordsPredicateTest.java
@@ -1,0 +1,69 @@
+package eatwhere.foodguide.model.eatery;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import eatwhere.foodguide.testutil.EateryBuilder;
+
+public class PriceContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("$");
+        List<String> secondPredicateKeywordList = Arrays.asList("$", "$$");
+
+        PriceContainsKeywordsPredicate firstPredicate = new PriceContainsKeywordsPredicate(firstPredicateKeywordList);
+        PriceContainsKeywordsPredicate secondPredicate =
+                new PriceContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        PriceContainsKeywordsPredicate firstPredicateCopy =
+                new PriceContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different eatery -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nameContainsKeywords_returnsTrue() {
+        // One keyword
+        PriceContainsKeywordsPredicate predicate = new PriceContainsKeywordsPredicate(Collections.singletonList("$$"));
+        assertTrue(predicate.test(new EateryBuilder().withPrice("$$").build()));
+
+        // Multiple keywords
+        predicate = new PriceContainsKeywordsPredicate(Arrays.asList("$$", "$"));
+        assertTrue(predicate.test(new EateryBuilder().withPrice("$$").build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        PriceContainsKeywordsPredicate predicate = new PriceContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new EateryBuilder().withPrice("$").build()));
+
+        // Non-matching keyword
+        predicate = new PriceContainsKeywordsPredicate(Arrays.asList("$$"));
+        assertFalse(predicate.test(new EateryBuilder().withPrice("$").build()));
+
+        // Keywords match all other fields, but does not match price
+        predicate = new PriceContainsKeywordsPredicate(Arrays.asList("Chinese", "Eatery", "NUS"));
+        assertFalse(predicate.test(new EateryBuilder().withName("Eatery").withPrice("$$")
+                .withCuisine("Chinese").withLocation("NUS").build()));
+    }
+}

--- a/src/test/java/eatwhere/foodguide/model/eatery/TagsContainsKeywordsPredicateTest.java
+++ b/src/test/java/eatwhere/foodguide/model/eatery/TagsContainsKeywordsPredicateTest.java
@@ -1,0 +1,75 @@
+package eatwhere.foodguide.model.eatery;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import eatwhere.foodguide.testutil.EateryBuilder;
+
+public class TagsContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("firstTag");
+        List<String> secondPredicateKeywordList = Arrays.asList("firstTag", "secondTag");
+
+        TagsContainsKeywordsPredicate firstPredicate = new TagsContainsKeywordsPredicate(firstPredicateKeywordList);
+        TagsContainsKeywordsPredicate secondPredicate = new TagsContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TagsContainsKeywordsPredicate firstPredicateCopy = new TagsContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different eatery -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nameContainsKeywords_returnsTrue() {
+        // One keyword
+        TagsContainsKeywordsPredicate predicate = new TagsContainsKeywordsPredicate(Collections.singletonList("tag1"));
+        assertTrue(predicate.test(new EateryBuilder().withTags("tag1").build()));
+
+        // Multiple keywords
+        predicate = new TagsContainsKeywordsPredicate(Arrays.asList("tag1", "tag2"));
+        assertTrue(predicate.test(new EateryBuilder().withTags("tag1", "tag2").build()));
+
+        // Only one matching keyword
+        predicate = new TagsContainsKeywordsPredicate(Arrays.asList("tag1", "tag2"));
+        assertTrue(predicate.test(new EateryBuilder().withTags("tag3", "tag2").build()));
+
+        // Mixed-case keywords
+        predicate = new TagsContainsKeywordsPredicate(Arrays.asList("Tag1", "TAG2"));
+        assertTrue(predicate.test(new EateryBuilder().withTags("tag1", "tag2").build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        TagsContainsKeywordsPredicate predicate = new TagsContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new EateryBuilder().withTags("tag").build()));
+
+        // Non-matching keyword
+        predicate = new TagsContainsKeywordsPredicate(Arrays.asList("tag1"));
+        assertFalse(predicate.test(new EateryBuilder().withTags("tag2", "tag3").build()));
+
+        // Keywords match other fields, but does not match tags
+        predicate = new TagsContainsKeywordsPredicate(Arrays.asList("$$", "Eatery", "NUS", "Chinese"));
+        assertFalse(predicate.test(new EateryBuilder().withName("Eatery").withPrice("$$")
+                .withCuisine("Chinese").withLocation("NUS").withTags("tag1", "tag2").build()));
+    }
+}


### PR DESCRIPTION
Added automated test cases for the following classes:
- NameContainsKeywordsPredicate
- LocationContainsKeywordsPredicate
- PriceContainsKeywordsPredicate
- TagsContainsKeywordsPredicate
- CuisineContainsKeywordsPredicate

Additionally, removed some redundant constructors for Eatery and Price as we now enforce Price as a compulsory field.

Updated coverage report by Jacoco -> most classes only have lapses in `equals()` and `hashCode()` functions:
![image](https://user-images.githubusercontent.com/88593616/200310348-61ae00d0-9f5d-4812-9ac7-5e600fa0470e.png)
